### PR TITLE
core: Make direct use of 'TypedId<Foo>' the preferred pattern.

### DIFF
--- a/core/src/main/java/com/geoffgranum/uttu/core/persistence/id/DefaultIdGenerator.java
+++ b/core/src/main/java/com/geoffgranum/uttu/core/persistence/id/DefaultIdGenerator.java
@@ -16,7 +16,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.ThreadSafe;
 import java.lang.management.ManagementFactory;
-import java.lang.reflect.Constructor;
 import java.math.BigInteger;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
@@ -128,7 +127,7 @@ public final class DefaultIdGenerator implements IdGenerator {
 
   @Override
   @Nonnull
-  public BigInteger nextId() {
+  public BigInteger next() {
     int nextAuto;
     synchronized (autoInc) {
       nextAuto = autoInc.getAndIncrement();
@@ -143,20 +142,6 @@ public final class DefaultIdGenerator implements IdGenerator {
     // copy lower-order bytes from the int as the auto increment value
     insertAsBytes(nextAuto, 1, bytes, 13, 3);
     return new BigInteger(bytes);
-  }
-
-  @Override
-  @Nonnull
-  public <T extends TypedId<?>> T nextId(Class<T> type) {
-    T id;
-    try {
-      @SuppressWarnings("rawtypes") Constructor constructor = type.getConstructor(BigInteger.class);
-      id = type.cast(constructor.newInstance(nextId()));
-    } catch (Exception e) {
-      /* Unless TypedId gets modified this won't happen. */
-      throw new RuntimeException(e);
-    }
-    return id;
   }
 
   @Nonnull

--- a/core/src/main/java/com/geoffgranum/uttu/core/persistence/id/TypedId.java
+++ b/core/src/main/java/com/geoffgranum/uttu/core/persistence/id/TypedId.java
@@ -15,7 +15,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.math.BigInteger;
 
-public class TypedId<T> implements Identifier, Comparable<TypedId<T>>, Serializable {
+public class TypedId<T extends Identified> implements Identifier, Comparable<TypedId<T>>, Serializable {
 
   private static final long serialVersionUID = 1L;
 

--- a/core/src/test/java/com/geoffgranum/uttu/core/persistence/id/DefaultIdGeneratorTest.java
+++ b/core/src/test/java/com/geoffgranum/uttu/core/persistence/id/DefaultIdGeneratorTest.java
@@ -29,7 +29,7 @@ public class DefaultIdGeneratorTest {
   public void testCanConvertToMongoStyleByteArray() throws Exception {
     int now = (int) (System.currentTimeMillis() / 1000);
     DefaultIdGenerator idGen = new DefaultIdGenerator();
-    String mongoId = idGen.asMongo(idGen.nextId());
+    String mongoId = idGen.asMongo(idGen.next());
     assertThat(mongoId.length(), is(24));
     // Reads the int from the beginning of the array, so it is in fact the time.
     int seconds = Ints.fromByteArray(Hex.decodeHex(mongoId.toCharArray()));

--- a/iam/src/main/java/com/geoffgranum/uttu/iam/domain/identity/tenant/Tenant.java
+++ b/iam/src/main/java/com/geoffgranum/uttu/iam/domain/identity/tenant/Tenant.java
@@ -7,7 +7,6 @@ package com.geoffgranum.uttu.iam.domain.identity.tenant;
 
 
 import com.geoffgranum.uttu.core.base.Verify;
-import com.geoffgranum.uttu.core.persistence.id.IdGenerator;
 import com.geoffgranum.uttu.core.persistence.id.Identified;
 import com.geoffgranum.uttu.iam.domain.access.registration.InvitationDescriptor;
 import com.geoffgranum.uttu.iam.domain.access.registration.RegistrationInvitation;
@@ -253,8 +252,8 @@ public final class Tenant implements Identified {
       return this;
     }
 
-    public Tenant create(IdGenerator gen) {
-      id(new TenantId(gen.nextId()));
+    public Tenant build(TenantId nextId) {
+      id(nextId);
       return this.build();
     }
 

--- a/iam/src/main/java/com/geoffgranum/uttu/iam/domain/identity/tenant/TenantProvisioningService.java
+++ b/iam/src/main/java/com/geoffgranum/uttu/iam/domain/identity/tenant/TenantProvisioningService.java
@@ -73,7 +73,7 @@ public class TenantProvisioningService {
         .description(tenantDescription)
         .serverHostname(tenantServerHostname)
         .active(true)
-        .create(idGen);
+        .build(idGen.nextConcrete(TenantId.class));
 
     this.tenantRepository.add(tenant);
 


### PR DESCRIPTION
Creating separate id classes for all Model types is overkill and annoying. Also makes marshalling/unmarshalling extremely annoying.